### PR TITLE
Added predefined imap-search criterias

### DIFF
--- a/lib/MailSo/Mail/MailClient.php
+++ b/lib/MailSo/Mail/MailClient.php
@@ -944,12 +944,21 @@ class MailClient
 			{
 				if (true)
 				{
-					$sValue = $this->escapeSearchString($aLines['OTHER']);
+                    if(\in_array($aLines['OTHER'], array(
+                        'ALL', 'ANSWERED', 'DELETED', 'FLAGGED',
+                        'NEW', 'OLD', 'RECENT', 'SEEN', 'UNSEEN', 
+                        'UNANSWERED', 'UNDELETED', 'UNFLAGGED'))) {
+                        $oSearchBuilder->AddOr($aLines['OTHER'], '');
+                    }
+                    else {                    
+                        
+                        $sValue = $this->escapeSearchString($aLines['OTHER']);
 
-					$oSearchBuilder->AddOr('FROM', $sValue);
-					$oSearchBuilder->AddOr('TO', $sValue);
-					$oSearchBuilder->AddOr('CC', $sValue);
-					$oSearchBuilder->AddOr('SUBJECT', $sValue);
+                        $oSearchBuilder->AddOr('FROM', $sValue);
+                        $oSearchBuilder->AddOr('TO', $sValue);
+                        $oSearchBuilder->AddOr('CC', $sValue);
+                        $oSearchBuilder->AddOr('SUBJECT', $sValue);
+                    }
 				}
 				else
 				{


### PR DESCRIPTION
I've noticed that "{imap.gmail.com:993} [Gmail]\All e-mail" returnes no messages when using `MailClient::MessageList`, although parameter `MessageCount` using `MailClient::FolderInformation` is non-zero. I don't known why, but I believe it is some sort of GMail/imap quark (`MessageCount` is actually much large than what the Gmail webmail client reports). 

Anyways, I've found a workaround, which was to use the predefined imap search query 'ALL' which MailSo do not currently support. 

This pull-request add support for all predefined imap search queries. 
